### PR TITLE
Escape usernames with underscore or asterisk

### DIFF
--- a/classes/Format.class.php
+++ b/classes/Format.class.php
@@ -41,8 +41,8 @@ class Format {
      */
     static function NoBBC($string) {
         return str_replace(
-            array('[', ']', '#', '<', '>'),
-            array('(', ')',  '', '(', ')'),
+            array('[', ']', '#', '<', '>', '_', '*'),
+            array('(', ')',  '', '(', ')', ' ', ''),
             $string
         );
     }


### PR DESCRIPTION
This is done mainly for Creator_AWS. 
Discord has highlighting for markdown in which they make text italics when underscore is used.